### PR TITLE
Fix center vector length

### DIFF
--- a/resources/drone_orbit.py
+++ b/resources/drone_orbit.py
@@ -45,7 +45,7 @@ class OrbitNavigator:
         # center is just a direction vector, so normalize it to compute the actual cx,cy locations.
         cx = float(center[0])
         cy = float(center[1])
-        length = math.sqrt(cx*cx)+(cy*cy)
+        length = math.sqrt((cx*cx)+(cy*cy))
         cx /= length
         cy /= length
         cx *= self.radius


### PR DESCRIPTION
Hi, I was reading through the drone orbitting code and realized that it seems like a pair of parenthesis is missing in the calculation of the center vector lenght.

I also saw that it's also missing it on the official AirSim repository ([here](https://github.com/microsoft/AirSim/blob/master/PythonClient/multirotor/orbit.py#L41)). Should I send a PR there as well, or is this intentional?