### PR TITLE
Fix home position stability check on drone_orbit.py

### DIFF
--- a/resources/drone_orbit.py
+++ b/resources/drone_orbit.py
@@ -60,10 +60,10 @@ class OrbitNavigator:
         start = time.time()
         count = 0
         while count < 100:
-            pos = self.home
+            pos = self.client.getMultirotorState().kinematics_estimated.position
             if abs(pos.z_val - self.home.z_val) > 1:
                 count = 0
-                self.home = pos
+                self.home = self.client.getMultirotorState().kinematics_estimated.position
                 if time.time() - start > 10:
                     print(
                         "Drone position is drifting, we are waiting for it to settle down...")
@@ -71,7 +71,7 @@ class OrbitNavigator:
             else:
                 count += 1
 
-        self.center = self.client.getMultirotorState().kinematics_estimated.position
+        self.center = pos
         self.center.x_val += cx
         self.center.y_val += cy
 


### PR DESCRIPTION
By assigning `pos = self.home`, both variables are pointing to the same address (which we can see by printing their [`id`](https://docs.python.org/3/library/functions.html#id) or verifying that `pos is self.home` is always True).

Thus, the `if` statement on line 64 always goes to the `else` branch:

https://github.com/microsoft/DroneRescue/blob/master/resources/drone_orbit.py#L63-L64

Also, we can avoid making another API call to the client when assigning `self.center` on line 74, since once we've reached this line we already know that the values of `pos` and `self.home` are stable.